### PR TITLE
update dependencies and lint self

### DIFF
--- a/base.js
+++ b/base.js
@@ -1,30 +1,30 @@
 module.exports = {
-  'parser': 'babel-eslint',             //     https://github.com/babel/babel-eslint
+    'parser': 'babel-eslint',             //     https://github.com/babel/babel-eslint
                                         //     Set these to true or false, depending on your usage
-  'ecmaFeatures': {
-    'arrowFunctions': true,
-    'blockBindings': true,
-    'classes': true,
-    'defaultParams': true,
-    'destructuring': true,
-    'forOf': true,
-    'generators': false,
-    'modules': true,
-    'objectLiteralComputedProperties': true,
-    'objectLiteralDuplicateProperties': false,
-    'objectLiteralShorthandMethods': true,
-    'objectLiteralShorthandProperties': true,
-    'spread': true,
-    'superInFunctions': true,
-    'templateStrings': true
-  },
-  'extends': [
-    'eslint-config-porch/env',
-    'eslint-config-porch/rules/best-practices',
-    'eslint-config-porch/rules/possible-errors',
-    'eslint-config-porch/rules/strict',
-    'eslint-config-porch/rules/style',
-    'eslint-config-porch/rules/variables'
-  ],
-  'rules': {}
+    'ecmaFeatures': {
+        'arrowFunctions': true,
+        'blockBindings': true,
+        'classes': true,
+        'defaultParams': true,
+        'destructuring': true,
+        'forOf': true,
+        'generators': false,
+        'modules': true,
+        'objectLiteralComputedProperties': true,
+        'objectLiteralDuplicateProperties': false,
+        'objectLiteralShorthandMethods': true,
+        'objectLiteralShorthandProperties': true,
+        'spread': true,
+        'superInFunctions': true,
+        'templateStrings': true
+    },
+    'extends': [
+        './env.js',
+        './rules/best-practices.js',
+        './rules/possible-errors.js',
+        './rules/strict.js',
+        './rules/style.js',
+        './rules/variables.js'
+    ],
+    'rules': {}
 };

--- a/env.js
+++ b/env.js
@@ -1,8 +1,8 @@
 module.exports = {
-  'env': {                              //     http://eslint.org/docs/user-guide/configuring.html#specifying-environments
-    'browser': true,                    // [x] browser global variables
-    'node': true,                       // [x] Node.js global variables and Node.js-specific rules
-    'mocha': true                       // [x] Mocha global variables and Node.js-specific rules
-  },
-  rules: {}
+    'env': {                              //     http://eslint.org/docs/user-guide/configuring.html#specifying-environments
+        'browser': true,                    // [x] browser global variables
+        'node': true,                       // [x] Node.js global variables and Node.js-specific rules
+        'mocha': true                       // [x] Mocha global variables and Node.js-specific rules
+    },
+    rules: {}
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = {
-  'extends': [
-    'eslint-config-porch/base',
-    'eslint-config-porch/rules/react'
-  ],
-  rules: {}
+    'extends': [
+        './base.js',
+        './rules/react.js'
+    ],
+    rules: {}
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Porch's eslint configuration.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "lint": "eslint . -c index.js"
   },
   "repository": {
     "type": "git",
@@ -15,5 +15,15 @@
   "bugs": {
     "url": "https://github.com/porchdotcom/eslint-config-porch/issues"
   },
-  "homepage": "https://github.com/porchdotcom/eslint-config-porch#readme"
+  "homepage": "https://github.com/porchdotcom/eslint-config-porch#readme",
+  "peerDependencies": {
+    "babel-eslint": "^5.0.0",
+    "eslint": "^2.2.0",
+    "eslint-plugin-react": "^4.0.0"
+  },
+  "devDependencies": {
+    "babel-eslint": "^5.0.0",
+    "eslint": "^2.2.0",
+    "eslint-plugin-react": "^4.0.0"
+  }
 }

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -2,47 +2,47 @@
  * Best practices
  */
 module.exports = {
-  'rules': {
-    'consistent-return': 2,             // [x] http://eslint.org/docs/rules/consistent-return
-    'curly': [2, 'multi-line'],         // [x] http://eslint.org/docs/rules/curly
-    'default-case': 2,                  // [x] http://eslint.org/docs/rules/default-case
-    'dot-notation': [2, {               // [x] http://eslint.org/docs/rules/dot-notation
-      'allowKeywords': true
-    }],
-    'eqeqeq': 2,                        // [x] http://eslint.org/docs/rules/eqeqeq
-    'guard-for-in': 2,                  // [x] http://eslint.org/docs/rules/guard-for-in
-    'no-caller': 2,                     // [x] http://eslint.org/docs/rules/no-caller
-    'no-else-return': 2,                // [x] http://eslint.org/docs/rules/no-else-return
-    'no-eq-null': 2,                    // [x] http://eslint.org/docs/rules/no-eq-null
-    'no-eval': 2,                       // [x] http://eslint.org/docs/rules/no-eval
-    'no-extend-native': 2,              // [x] http://eslint.org/docs/rules/no-extend-native
-    'no-extra-bind': 2,                 // [x] http://eslint.org/docs/rules/no-extra-bind
-    'no-fallthrough': 2,                // [x] http://eslint.org/docs/rules/no-fallthrough
-    'no-floating-decimal': 2,           // [x] http://eslint.org/docs/rules/no-floating-decimal
-    'no-implied-eval': 2,               // [x] http://eslint.org/docs/rules/no-implied-eval
-    'no-lone-blocks': 2,                // [x] http://eslint.org/docs/rules/no-lone-blocks
-    'no-loop-func': 2,                  // [x] http://eslint.org/docs/rules/no-loop-func
-    'no-multi-str': 2,                  // [x] http://eslint.org/docs/rules/no-multi-str
-    'no-native-reassign': 2,            // [x] http://eslint.org/docs/rules/no-native-reassign
-    'no-new': 2,                        // [x] http://eslint.org/docs/rules/no-new
-    'no-new-func': 2,                   // [x] http://eslint.org/docs/rules/no-new-func
-    'no-new-wrappers': 2,               // [x] http://eslint.org/docs/rules/no-new-wrappers
-    'no-octal': 2,                      // [x] http://eslint.org/docs/rules/no-octal
-    'no-octal-escape': 2,               // [x] http://eslint.org/docs/rules/no-octal-escape
-    'no-param-reassign': 2,             // [x] http://eslint.org/docs/rules/no-param-reassign
-    'no-proto': 2,                      // [x] http://eslint.org/docs/rules/no-proto
-    'no-redeclare': 2,                  // [x] http://eslint.org/docs/rules/no-redeclare
-    'no-return-assign': 2,              // [x] http://eslint.org/docs/rules/no-return-assign
-    'no-script-url': 2,                 // [x] http://eslint.org/docs/rules/no-script-url
-    'no-self-compare': 2,               // [x] http://eslint.org/docs/rules/no-self-compare
-    'no-sequences': 2,                  // [x] http://eslint.org/docs/rules/no-sequences
-    'no-throw-literal': 2,              // [x] http://eslint.org/docs/rules/no-throw-literal
-    'no-with': 2,                       // [x] http://eslint.org/docs/rules/no-with
-    'radix': 2,                         // [x] http://eslint.org/docs/rules/radix
+    'rules': {
+        'consistent-return': 2,             // [x] http://eslint.org/docs/rules/consistent-return
+        'curly': [2, 'multi-line'],         // [x] http://eslint.org/docs/rules/curly
+        'default-case': 2,                  // [x] http://eslint.org/docs/rules/default-case
+        'dot-notation': [2, {               // [x] http://eslint.org/docs/rules/dot-notation
+            'allowKeywords': true
+        }],
+        'eqeqeq': 2,                        // [x] http://eslint.org/docs/rules/eqeqeq
+        'guard-for-in': 2,                  // [x] http://eslint.org/docs/rules/guard-for-in
+        'no-caller': 2,                     // [x] http://eslint.org/docs/rules/no-caller
+        'no-else-return': 2,                // [x] http://eslint.org/docs/rules/no-else-return
+        'no-eq-null': 2,                    // [x] http://eslint.org/docs/rules/no-eq-null
+        'no-eval': 2,                       // [x] http://eslint.org/docs/rules/no-eval
+        'no-extend-native': 2,              // [x] http://eslint.org/docs/rules/no-extend-native
+        'no-extra-bind': 2,                 // [x] http://eslint.org/docs/rules/no-extra-bind
+        'no-fallthrough': 2,                // [x] http://eslint.org/docs/rules/no-fallthrough
+        'no-floating-decimal': 2,           // [x] http://eslint.org/docs/rules/no-floating-decimal
+        'no-implied-eval': 2,               // [x] http://eslint.org/docs/rules/no-implied-eval
+        'no-lone-blocks': 2,                // [x] http://eslint.org/docs/rules/no-lone-blocks
+        'no-loop-func': 2,                  // [x] http://eslint.org/docs/rules/no-loop-func
+        'no-multi-str': 2,                  // [x] http://eslint.org/docs/rules/no-multi-str
+        'no-native-reassign': 2,            // [x] http://eslint.org/docs/rules/no-native-reassign
+        'no-new': 2,                        // [x] http://eslint.org/docs/rules/no-new
+        'no-new-func': 2,                   // [x] http://eslint.org/docs/rules/no-new-func
+        'no-new-wrappers': 2,               // [x] http://eslint.org/docs/rules/no-new-wrappers
+        'no-octal': 2,                      // [x] http://eslint.org/docs/rules/no-octal
+        'no-octal-escape': 2,               // [x] http://eslint.org/docs/rules/no-octal-escape
+        'no-param-reassign': 2,             // [x] http://eslint.org/docs/rules/no-param-reassign
+        'no-proto': 2,                      // [x] http://eslint.org/docs/rules/no-proto
+        'no-redeclare': 2,                  // [x] http://eslint.org/docs/rules/no-redeclare
+        'no-return-assign': 2,              // [x] http://eslint.org/docs/rules/no-return-assign
+        'no-script-url': 2,                 // [x] http://eslint.org/docs/rules/no-script-url
+        'no-self-compare': 2,               // [x] http://eslint.org/docs/rules/no-self-compare
+        'no-sequences': 2,                  // [x] http://eslint.org/docs/rules/no-sequences
+        'no-throw-literal': 2,              // [x] http://eslint.org/docs/rules/no-throw-literal
+        'no-with': 2,                       // [x] http://eslint.org/docs/rules/no-with
+        'radix': 2,                         // [x] http://eslint.org/docs/rules/radix
 
                                         //     TODO: This change is coming.
-    'vars-on-top': 0,                   // [x] http://eslint.org/docs/rules/vars-on-top
-    'wrap-iife': [2, 'any'],            // [x] http://eslint.org/docs/rules/wrap-iife
-    'yoda': 2                           // [x] http://eslint.org/docs/rules/yoda
-  }
+        'vars-on-top': 0,                   // [x] http://eslint.org/docs/rules/vars-on-top
+        'wrap-iife': [2, 'any'],            // [x] http://eslint.org/docs/rules/wrap-iife
+        'yoda': 2                           // [x] http://eslint.org/docs/rules/yoda
+    }
 };

--- a/rules/possible-errors.js
+++ b/rules/possible-errors.js
@@ -2,27 +2,27 @@
  * Possible errors
  */
 module.exports = {
-  'rules': {
-    'comma-dangle': [2, 'never'],       // [x] http://eslint.org/docs/rules/comma-dangle
-    'no-cond-assign': [2, 'always'],    // [x] http://eslint.org/docs/rules/no-cond-assign
-    'no-console': 1,                    // [x] http://eslint.org/docs/rules/no-console
-    'no-debugger': 2,                   // [x] http://eslint.org/docs/rules/no-debugger
-    'no-alert': 1,                      // [x] http://eslint.org/docs/rules/no-alert
-    'no-constant-condition': 1,         // [x] http://eslint.org/docs/rules/no-constant-condition
-    'no-dupe-keys': 2,                  // [x] http://eslint.org/docs/rules/no-dupe-keys
-    'no-duplicate-case': 2,             // [x] http://eslint.org/docs/rules/no-duplicate-case
-    'no-empty': 2,                      // [x] http://eslint.org/docs/rules/no-empty
-    'no-ex-assign': 2,                  // [x] http://eslint.org/docs/rules/no-ex-assign
-    'no-extra-boolean-cast': 0,         // [x] http://eslint.org/docs/rules/no-extra-boolean-cast
-    'no-extra-semi': 2,                 // [x] http://eslint.org/docs/rules/no-extra-semi
-    'no-func-assign': 2,                // [x] http://eslint.org/docs/rules/no-func-assign
-    'no-inner-declarations': 2,         // [x] http://eslint.org/docs/rules/no-inner-declarations
-    'no-invalid-regexp': 2,             // [x] http://eslint.org/docs/rules/no-invalid-regexp
-    'no-irregular-whitespace': 2,       // [x] http://eslint.org/docs/rules/no-irregular-whitespace
-    'no-obj-calls': 2,                  // [x] http://eslint.org/docs/rules/no-obj-calls
-    'no-sparse-arrays': 2,              // [x] http://eslint.org/docs/rules/no-sparse-arrays
-    'no-unreachable': 2,                // [x] http://eslint.org/docs/rules/no-unreachable
-    'use-isnan': 2,                     // [x] http://eslint.org/docs/rules/use-isnan
-    'block-scoped-var': 2               // [x] http://eslint.org/docs/rules/block-scoped-var
-  }
+    'rules': {
+        'comma-dangle': [2, 'never'],       // [x] http://eslint.org/docs/rules/comma-dangle
+        'no-cond-assign': [2, 'always'],    // [x] http://eslint.org/docs/rules/no-cond-assign
+        'no-console': 1,                    // [x] http://eslint.org/docs/rules/no-console
+        'no-debugger': 2,                   // [x] http://eslint.org/docs/rules/no-debugger
+        'no-alert': 1,                      // [x] http://eslint.org/docs/rules/no-alert
+        'no-constant-condition': 1,         // [x] http://eslint.org/docs/rules/no-constant-condition
+        'no-dupe-keys': 2,                  // [x] http://eslint.org/docs/rules/no-dupe-keys
+        'no-duplicate-case': 2,             // [x] http://eslint.org/docs/rules/no-duplicate-case
+        'no-empty': 2,                      // [x] http://eslint.org/docs/rules/no-empty
+        'no-ex-assign': 2,                  // [x] http://eslint.org/docs/rules/no-ex-assign
+        'no-extra-boolean-cast': 0,         // [x] http://eslint.org/docs/rules/no-extra-boolean-cast
+        'no-extra-semi': 2,                 // [x] http://eslint.org/docs/rules/no-extra-semi
+        'no-func-assign': 2,                // [x] http://eslint.org/docs/rules/no-func-assign
+        'no-inner-declarations': 2,         // [x] http://eslint.org/docs/rules/no-inner-declarations
+        'no-invalid-regexp': 2,             // [x] http://eslint.org/docs/rules/no-invalid-regexp
+        'no-irregular-whitespace': 2,       // [x] http://eslint.org/docs/rules/no-irregular-whitespace
+        'no-obj-calls': 2,                  // [x] http://eslint.org/docs/rules/no-obj-calls
+        'no-sparse-arrays': 2,              // [x] http://eslint.org/docs/rules/no-sparse-arrays
+        'no-unreachable': 2,                // [x] http://eslint.org/docs/rules/no-unreachable
+        'use-isnan': 2,                     // [x] http://eslint.org/docs/rules/use-isnan
+        'block-scoped-var': 2               // [x] http://eslint.org/docs/rules/block-scoped-var
+    }
 };

--- a/rules/react.js
+++ b/rules/react.js
@@ -1,62 +1,63 @@
 module.exports = {
-  'plugins': [
-    'react'                             // [x] https://github.com/yannickcr/eslint-plugin-react
-  ],
-  'ecmaFeatures': {
-    'jsx': true
-  },
-  'rules': {
+    'plugins': [
+        'react'                             // [x] https://github.com/yannickcr/eslint-plugin-react
+    ],
+    'ecmaFeatures': {
+        'jsx': true
+    },
+    'rules': {
 
 /**
  * JSX style
  */
-    'jsx-quotes': [                     // [x] http://eslint.org/docs/rules/jsx-quotes
-      2, 'prefer-double'
-    ],
-    'react/display-name': 0,            // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/display-name.md
-    'react/jsx-boolean-value': [        // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md
-        2, 'always'
-    ],
-    'react/jsx-no-undef': 2,            // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-undef.md
-    'react/jsx-sort-props': 2,          // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md
-    'react/jsx-sort-prop-types': 2,     // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-prop-types.md
-    'react/jsx-uses-react': 2,          // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md
-    'react/jsx-uses-vars': 2,           // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-vars.md
-    'react/no-did-mount-set-state': [   // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-mount-set-state.md
-        2, 'allow-in-func'
-    ],
-    'react/no-did-update-set-state': 2, // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md
-    'react/no-multi-comp': 2,           // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md
-    'react/no-unknown-property': 2,     // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md
-    'react/prop-types': 2,              // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md
-    'react/react-in-jsx-scope': 2,      // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
-    'react/self-closing-comp': 2,       // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md
-    'react/wrap-multilines': 2,         // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md
-    'react/sort-comp': [2, {            // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md
-      'order': [
-        'displayName',
-        'propTypes',
-        'contextTypes',
-        'childContextTypes',
-        'mixins',
-        'statics',
-        'defaultProps',
-        'constructor',
-        'getDefaultProps',
-        'getInitialState',
-        'getChildContext',
-        'componentWillMount',
-        'componentDidMount',
-        'componentWillReceiveProps',
-        'shouldComponentUpdate',
-        'componentWillUpdate',
-        'componentDidUpdate',
-        'componentWillUnmount',
-        '/^on.+$/',
-        '/^get.+$/',
-        '/^render.+$/',
-        'render'
-      ]
-    }]
-  }
+        'jsx-quotes': [                     // [x] http://eslint.org/docs/rules/jsx-quotes
+            2, 'prefer-double'
+        ],
+        'react/display-name': 0,            // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/display-name.md
+        'react/jsx-boolean-value': [        // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md
+            2, 'always'
+        ],
+        'react/jsx-no-undef': 2,            // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-undef.md
+        'react/jsx-sort-props': 2,          // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md
+        'react/sort-prop-types': 2,     // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-prop-types.md
+        'react/jsx-uses-react': 2,          // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md
+        'react/jsx-uses-vars': 2,           // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-vars.md
+        'react/no-did-mount-set-state': [   // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-mount-set-state.md
+            2, 'allow-in-func'
+        ],
+        'react/no-did-update-set-state': 2, // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md
+        'react/no-multi-comp': 2,           // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md
+        'react/no-unknown-property': 2,     // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md
+        'react/prop-types': 2,              // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md
+        'react/react-in-jsx-scope': 2,      // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
+        'react/self-closing-comp': 2,       // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md
+        'react/wrap-multilines': 2,         // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md
+        'react/sort-comp': [2, {            // [x] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md
+            'order': [
+                'displayName',
+                'propTypes',
+                'contextTypes',
+                'childContextTypes',
+                'mixins',
+                'statics',
+                'defaultProps',
+                'constructor',
+                'getDefaultProps',
+                'getInitialState',
+                'getChildContext',
+                'componentWillMount',
+                'componentDidMount',
+                'componentWillReceiveProps',
+                'shouldComponentUpdate',
+                'componentWillUpdate',
+                'componentDidUpdate',
+                'componentWillUnmount',
+                '/^on.+$/',
+                '/^get.+$/',
+                '/^render.+$/',
+                'render'
+            ]
+        }],
+        'react/no-deprecated': 2
+    }
 };

--- a/rules/strict.js
+++ b/rules/strict.js
@@ -1,6 +1,6 @@
 module.exports = {
-  'rules': {
+    'rules': {
     // babel inserts "use strict" for us.
-    'strict': [2, 'never']              // [x] http://eslint.org/docs/rules/strict
-  }
+        'strict': [2, 'never']              // [x] http://eslint.org/docs/rules/strict
+    }
 };

--- a/rules/style.js
+++ b/rules/style.js
@@ -2,61 +2,59 @@
  * Style Rules
  */
 module.exports = {
-  'rules': {
-    'indent': [2, 4],                   // [x] http://eslint.org/docs/rules/indent
-    'brace-style': [2,                  // [x] http://eslint.org/docs/rules/brace-style
-      '1tbs', {
-      'allowSingleLine': true
-    }],
-    'quotes': [
-      2, 'single', 'avoid-escape'       // [x] http://eslint.org/docs/rules/quotes
-    ],
-    'camelcase': [2, {                  // [x] http://eslint.org/docs/rules/camelcase
-      'properties': 'never'
-    }],
-    'comma-spacing': [2, {              // [x] http://eslint.org/docs/rules/comma-spacing
-      'before': false,
-      'after': true
-    }],
-    'comma-style': [2, 'last'],         // [x] http://eslint.org/docs/rules/comma-style
-    'eol-last': 2,                      // [x] http://eslint.org/docs/rules/eol-last
+    'rules': {
+        'indent': [2, 4],                   // [x] http://eslint.org/docs/rules/indent
+        'brace-style': [2,                  // [x] http://eslint.org/docs/rules/brace-style
+        '1tbs', {
+            'allowSingleLine': true
+        }],
+        'quotes': [
+            2, 'single', 'avoid-escape'       // [x] http://eslint.org/docs/rules/quotes
+        ],
+        'camelcase': [2, {                  // [x] http://eslint.org/docs/rules/camelcase
+            'properties': 'never'
+        }],
+        'comma-spacing': [2, {              // [x] http://eslint.org/docs/rules/comma-spacing
+            'before': false,
+            'after': true
+        }],
+        'comma-style': [2, 'last'],         // [x] http://eslint.org/docs/rules/comma-style
+        'eol-last': 2,                      // [x] http://eslint.org/docs/rules/eol-last
 
                                         //     TODO: This change is coming.
-    'func-names': 0,                    // [x] http://eslint.org/docs/rules/func-names
-    'key-spacing': [2, {                // [x] http://eslint.org/docs/rules/key-spacing
-        'beforeColon': false,
-        'afterColon': true
-    }],
-    'new-cap': [0, {                    // [x] http://eslint.org/docs/rules/new-cap
-      'newIsCap': true
-    }],
-    'no-multiple-empty-lines': [2, {    // [x] http://eslint.org/docs/rules/no-multiple-empty-lines
-      'max': 2
-    }],
-    'no-nested-ternary': 2,             // [x] http://eslint.org/docs/rules/no-nested-ternary
-    'no-new-object': 2,                 // [x] http://eslint.org/docs/rules/no-new-object
-    'no-spaced-func': 2,                // [x] http://eslint.org/docs/rules/no-spaced-func
-    'no-trailing-spaces': 2,            // [x] http://eslint.org/docs/rules/no-trailing-spaces
-    'no-extra-parens': [2,              // [x] http://eslint.org/docs/rules/no-extra-parens
+        'func-names': 0,                    // [x] http://eslint.org/docs/rules/func-names
+        'key-spacing': [2, {                // [x] http://eslint.org/docs/rules/key-spacing
+            'beforeColon': false,
+            'afterColon': true
+        }],
+        'new-cap': [0, {                    // [x] http://eslint.org/docs/rules/new-cap
+            'newIsCap': true
+        }],
+        'no-multiple-empty-lines': [2, {    // [x] http://eslint.org/docs/rules/no-multiple-empty-lines
+            'max': 2
+        }],
+        'no-nested-ternary': 2,             // [x] http://eslint.org/docs/rules/no-nested-ternary
+        'no-new-object': 2,                 // [x] http://eslint.org/docs/rules/no-new-object
+        'no-spaced-func': 2,                // [x] http://eslint.org/docs/rules/no-spaced-func
+        'no-trailing-spaces': 2,            // [x] http://eslint.org/docs/rules/no-trailing-spaces
+        'no-extra-parens': [2,              // [x] http://eslint.org/docs/rules/no-extra-parens
         'functions'],
-    'no-mixed-spaces-and-tabs': 2,      // [x] http://eslint.org/docs/rules/no-mixed-spaces-and-tabs
-    'no-underscore-dangle': 0,          // [x] http://eslint.org/docs/rules/no-underscore-dangle
-    'one-var': [2, 'never'],            // [x] http://eslint.org/docs/rules/one-var
-    'padded-blocks': [0, 'never'],      // [x] http://eslint.org/docs/rules/padded-blocks
-    'semi': [2, 'always'],              // [x] http://eslint.org/docs/rules/semi
-    'semi-spacing': [2, {               // [x] http://eslint.org/docs/rules/semi-spacing
-      'before': false,
-      'after': true
-    }],
-    'space-after-keywords': 2,          // [x] http://eslint.org/docs/rules/space-after-keywords
-    'space-before-blocks': 2,           // [x] http://eslint.org/docs/rules/space-before-blocks
-    'space-before-function-paren': [2,  // [x] http://eslint.org/docs/rules/space-before-function-paren
-    {
-        'anonymous': 'always',
-        'named': 'never'
-    }],
-    'space-infix-ops': 2,               // [x] http://eslint.org/docs/rules/space-infix-ops
-    'space-return-throw-case': 2,       // [x] http://eslint.org/docs/rules/space-return-throw-case
-    'spaced-comment': 2                 // [x] http://eslint.org/docs/rules/spaced-comment
-  }
+        'no-mixed-spaces-and-tabs': 2,      // [x] http://eslint.org/docs/rules/no-mixed-spaces-and-tabs
+        'no-underscore-dangle': 0,          // [x] http://eslint.org/docs/rules/no-underscore-dangle
+        'one-var': [2, 'never'],            // [x] http://eslint.org/docs/rules/one-var
+        'padded-blocks': [0, 'never'],      // [x] http://eslint.org/docs/rules/padded-blocks
+        'semi': [2, 'always'],              // [x] http://eslint.org/docs/rules/semi
+        'semi-spacing': [2, {               // [x] http://eslint.org/docs/rules/semi-spacing
+            'before': false,
+            'after': true
+        }],
+        'keyword-spacing': 2,               // [x] http://eslint.org/docs/rules/keyword-spacing
+        'space-before-blocks': 2,           // [x] http://eslint.org/docs/rules/space-before-blocks
+        'space-before-function-paren': [2, {// [x] http://eslint.org/docs/rules/space-before-function-paren
+            'anonymous': 'always',
+            'named': 'never'
+        }],
+        'space-infix-ops': 2,               // [x] http://eslint.org/docs/rules/space-infix-ops
+        'spaced-comment': 2                 // [x] http://eslint.org/docs/rules/spaced-comment
+    }
 };

--- a/rules/variables.js
+++ b/rules/variables.js
@@ -2,14 +2,14 @@
  * Variables
  */
 module.exports = {
-  'rules': {
-    'no-shadow': 2,                     // [x] http://eslint.org/docs/rules/no-shadow
-    'no-shadow-restricted-names': 2,    // [x] http://eslint.org/docs/rules/no-shadow-restricted-names
-    'no-unused-vars': [2, {             // [x] http://eslint.org/docs/rules/no-unused-vars
-      'vars': 'local',
-      'args': 'after-used'
-    }],
-    'no-use-before-define': 2,          // [x] http://eslint.org/docs/rules/no-use-before-define
-    'no-undef': 2                       // [x] http://eslint.org/docs/rules/no-undef
-  }
+    'rules': {
+        'no-shadow': 2,                     // [x] http://eslint.org/docs/rules/no-shadow
+        'no-shadow-restricted-names': 2,    // [x] http://eslint.org/docs/rules/no-shadow-restricted-names
+        'no-unused-vars': [2, {             // [x] http://eslint.org/docs/rules/no-unused-vars
+            'vars': 'local',
+            'args': 'after-used'
+        }],
+        'no-use-before-define': 2,          // [x] http://eslint.org/docs/rules/no-use-before-define
+        'no-undef': 2                       // [x] http://eslint.org/docs/rules/no-undef
+    }
 };


### PR DESCRIPTION
version bumps of babel-eslint, eslint-plugin-react, and eslint, as well as making those peer dependencies.

no rule changes, but the underlying default may have changed, hence the major version bump.